### PR TITLE
I've updated the `APPLICATION_SUMMARY.md` file to include information…

### DIFF
--- a/APPLICATION_SUMMARY.md
+++ b/APPLICATION_SUMMARY.md
@@ -131,6 +131,13 @@ All routes are prefixed with `/api`. Authentication (`protect`) is applied to mo
     *   Body: (Fields to update, e.g., `actualCost`, `serviceStatus`, `notes`)
 *   **`DELETE /:id`**: Delete a service/repair request. (Protected, OwnerOnly).
 
+### 4.7. Analytics API (`/analytics`)
+
+Provides endpoints for data aggregation and analytics. All routes are protected.
+
+*   **`GET /sales-summary`**: Retrieves sales Key Performance Indicators (KPIs) such as total revenue, average order value, total orders, and total items sold. Supports `startDate` and `endDate` query parameters for filtering.
+*   **`GET /sales-over-time`**: Retrieves sales trend data (revenue and order count) grouped by specified periods (daily, weekly, monthly). Supports `startDate`, `endDate`, and `period` query parameters.
+
 ## 5. Middleware
 
 *   **`authMiddleware.js`**:


### PR DESCRIPTION
… about the new Analytics API.

This commit adds a new sub-section (4.7) under "API Endpoints" that details the recently added Analytics API.

The new sub-section briefly describes:
-   `GET /analytics/sales-summary`: For sales KPIs, with `startDate` and `endDate` query parameters.
-   `GET /analytics/sales-over-time`: For sales trends, with `startDate`, `endDate`, and `period` query parameters.

This ensures the application summary document reflects the latest API capabilities.